### PR TITLE
feat(middleware): add functional options to Gzip middleware

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,7 +60,7 @@ func New(cfg *config.Config, logger logrus.FieldLogger) (*http.Server, error) {
 	handler = middleware.CORS()(handler)
 	handler = middleware.Recovery(logger)(handler)
 	handler = middleware.Metrics()(handler)
-	handler = middleware.Gzip()(handler)
+	handler = middleware.Gzip(middleware.WithExcludePaths("/metrics"))(handler)
 
 	return &http.Server{
 		Addr:              fmt.Sprintf("%s:%d", cfg.Server.Host, cfg.Server.Port),


### PR DESCRIPTION
Dont double-dip compressions. Prom handler deals with gzipping itself.