### PR TITLE
feat: embed version information into binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,10 +13,12 @@ builds:
     binary: server
     goos:
     - linux
-    goarch: 
+    goarch:
     - amd64
     ldflags:
       - -s -w
+      - -X github.com/ethpandaops/xatu-cbt-api/internal/version.Release={{.Tag}}-{{.ShortCommit}}
+      - -X github.com/ethpandaops/xatu-cbt-api/internal/version.GitCommit={{.ShortCommit}}
     mod_timestamp: "{{ .CommitTimestamp }}"
 
   - id: linux-arm64
@@ -24,12 +26,14 @@ builds:
       - CGO_ENABLED=0
     main: ./cmd/server
     binary: server
-    goos: 
+    goos:
     - linux
-    goarch: 
+    goarch:
     - arm64
     ldflags:
       - -s -w
+      - -X github.com/ethpandaops/xatu-cbt-api/internal/version.Release={{.Tag}}-{{.ShortCommit}}
+      - -X github.com/ethpandaops/xatu-cbt-api/internal/version.GitCommit={{.ShortCommit}}
     mod_timestamp: "{{ .CommitTimestamp }}"
 checksum:
   name_template: 'checksums.txt'
@@ -60,6 +64,8 @@ dockers:
       - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-amd64"
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg=VERSION={{.Tag}}"
+      - "--build-arg=GIT_COMMIT={{.ShortCommit}}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -81,6 +87,8 @@ dockers:
       - "ethpandaops/{{ .ProjectName }}:{{ if .Env.RELEASE_SUFFIX }}{{ .Env.RELEASE_SUFFIX }}-{{ end }}latest-arm64v8"
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--build-arg=VERSION={{.Tag}}"
+      - "--build-arg=GIT_COMMIT={{.ShortCommit}}"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,13 @@ WORKDIR /build
 
 COPY . .
 
+# Build arguments for version info
+ARG VERSION=dev
+ARG GIT_COMMIT=dev
+
 RUN make install-tools
 RUN make generate
-RUN make build
+RUN VERSION=${VERSION} GIT_COMMIT=${GIT_COMMIT} make build
 
 FROM alpine:latest
 

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,22 @@ install-tools:
 generate: .clone-xatu-cbt .build-tools .openapi .generate-descriptors .generate-server
 	@printf "$(GREEN)✓ Code generation complete$(RESET)\n"
 
+# Version information
+VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
+BUILD_DATE := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+DIRTY_SUFFIX := $(shell git diff --quiet || echo "-dirty")
+
+# Build ldflags
+LDFLAGS := -s -w \
+	-X github.com/ethpandaops/xatu-cbt-api/internal/version.Release=$(VERSION)-$(GIT_COMMIT)$(DIRTY_SUFFIX) \
+	-X github.com/ethpandaops/xatu-cbt-api/internal/version.GitCommit=$(GIT_COMMIT)
+
 # Build the API server binary
 build:
 	@printf "$(CYAN)==> Building API server...$(RESET)\n"
-	@go build -o bin/server ./cmd/server
+	@printf "$(CYAN)    Version: $(VERSION)-$(GIT_COMMIT)$(DIRTY_SUFFIX)$(RESET)\n"
+	@go build -ldflags "$(LDFLAGS)" -o bin/server ./cmd/server
 	@printf "$(GREEN)✓ Server built: bin/server$(RESET)\n"
 
 # Run the API server

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethpandaops/xatu-cbt-api/internal/config"
 	"github.com/ethpandaops/xatu-cbt-api/internal/server"
 	"github.com/ethpandaops/xatu-cbt-api/internal/telemetry"
+	"github.com/ethpandaops/xatu-cbt-api/internal/version"
 )
 
 func main() {
@@ -24,6 +25,12 @@ func main() {
 	})
 	logger.SetOutput(os.Stdout)
 	logger.SetLevel(logrus.InfoLevel)
+
+	// Log version information
+	logger.WithFields(logrus.Fields{
+		"version":  version.Short(),
+		"platform": version.FullWithPlatform(),
+	}).Info("Starting xatu-cbt-api")
 
 	// Load config
 	cfg, err := config.Load()

--- a/internal/handlers/health.go
+++ b/internal/handlers/health.go
@@ -3,17 +3,21 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/ethpandaops/xatu-cbt-api/internal/version"
 )
 
 // HealthResponse represents the health check response.
 type HealthResponse struct {
-	Status string `json:"status"`
+	Status  string `json:"status"`
+	Version string `json:"version"`
 }
 
 // Health handles health check requests.
 func Health(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(HealthResponse{
-		Status: "ok",
+		Status:  "ok",
+		Version: version.Short(),
 	})
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -16,6 +16,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/ethpandaops/xatu-cbt-api/internal/config"
+	"github.com/ethpandaops/xatu-cbt-api/internal/version"
 )
 
 // Service defines the telemetry service interface.
@@ -61,6 +62,7 @@ func (s *service) Start(ctx context.Context) error {
 	s.log.WithFields(logrus.Fields{
 		"endpoint":     s.config.Endpoint,
 		"service_name": s.config.ServiceName,
+		"version":      version.Short(),
 		"environment":  s.config.Environment,
 		"network_name": s.networkName,
 		"sample_rate":  s.config.SampleRate,
@@ -167,7 +169,7 @@ func (s *service) createResource() (*resource.Resource, error) {
 		resource.Default(),
 		resource.NewSchemaless(
 			semconv.ServiceName(s.config.ServiceName),
-			semconv.ServiceVersion(s.config.ServiceVersion),
+			semconv.ServiceVersion(version.Short()),
 			AttrNetworkName.String(s.networkName),
 		),
 	)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	// Release is the semantic version (set via ldflags).
+	Release = "dev"
+	// GitCommit is the git commit hash (set via ldflags).
+	GitCommit = "dev"
+	// Implementation is the name of the implementation.
+	Implementation = "xatu-cbt-api"
+	// GOOS is the operating system.
+	GOOS = runtime.GOOS
+	// GOARCH is the architecture.
+	GOARCH = runtime.GOARCH
+)
+
+// Full returns the full version string including implementation and version.
+func Full() string {
+	return fmt.Sprintf("%s/%s", Implementation, Short())
+}
+
+// Short returns the short version string.
+func Short() string {
+	return Release
+}
+
+// FullWithGOOS returns the full version with OS.
+func FullWithGOOS() string {
+	return fmt.Sprintf("%s/%s", Full(), GOOS)
+}
+
+// FullWithPlatform returns the full version with OS and architecture.
+func FullWithPlatform() string {
+	return fmt.Sprintf("%s/%s/%s", Full(), GOOS, GOARCH)
+}


### PR DESCRIPTION
- Add internal/version package to hold release and git commit data
- Inject Release and GitCommit via ldflags in Makefile and goreleaser
- Log version details on server startup for observability
- Extend /health response to include version string
- Pass VERSION and GIT_COMMIT as Docker build args for reproducible images