### PR TITLE
feat: add support for excluding tables from API via wildcard patterns

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -56,6 +56,8 @@ jobs:
             discovery:
               prefixes:
                 - fct
+              exclude:
+                - "*_local"  # Exclude all local tables
 
           proto:
             output_dir: "./pkg/proto/clickhouse"
@@ -67,6 +69,8 @@ jobs:
             base_path: "/api/v1"
             expose_prefixes:
               - fct
+            exclude:
+              - "*_local"
           EOF
       - name: Install tools, generate code and build
         run: |

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ run: build-binary
 	DISCOVERY_PREFIXES=$$(yq eval '.clickhouse.discovery.prefixes | join(",")' $(CONFIG_FILE)); \
 	DISCOVERY_EXCLUDE=$$(yq eval '(.clickhouse.discovery.exclude // []) | join(",")' $(CONFIG_FILE)); \
 	PREFIX_CONDITIONS=$$(echo "$$DISCOVERY_PREFIXES" | tr ',' '\n' | sed "s/^/name LIKE '/; s/$$/_%%'/" | paste -sd'|' - | sed 's/|/ OR /g'); \
-	EXCLUDE_CONDITIONS=$$(echo "$$DISCOVERY_EXCLUDE" | tr ',' '\n' | sed "s/^/name NOT LIKE '/; s/$$/'/" | paste -sd'&' - | sed 's/&/ AND /g'); \
+	EXCLUDE_CONDITIONS=$$(echo "$$DISCOVERY_EXCLUDE" | tr ',' '\n' | sed "s/\*/%%/g; s/^/name NOT LIKE '/; s/$$/'/" | paste -sd'&' - | sed 's/&/ AND /g'); \
 	QUERY="SELECT arrayStringConcat(groupArray(name), ',') FROM system.tables WHERE database = '$$CH_DB' AND ($$PREFIX_CONDITIONS)"; \
 	if [ -n "$$EXCLUDE_CONDITIONS" ]; then QUERY="$$QUERY AND ($$EXCLUDE_CONDITIONS)"; fi; \
 	CH_PROTO=$$(echo "$$CH_DSN" | sed 's|^\([^:]*\)://.*|\1|'); \
@@ -276,7 +276,8 @@ run: build-binary
 		--input $(TMP_DIR)/openapi.yaml \
 		--output $(OUTPUT_FILE) \
 		--proto-path $(PROTO_PATH) \
-		--descriptor .descriptors.pb
+		--descriptor .descriptors.pb \
+		--config $(CONFIG_FILE)
 	@printf "$(GREEN)✓ Pre-processed spec generated: $(OUTPUT_FILE)$(RESET)\n"
 
 .generate-descriptors: .download-googleapis

--- a/cmd/tools/openapi-preprocess/main_test.go
+++ b/cmd/tools/openapi-preprocess/main_test.go
@@ -899,12 +899,15 @@ func TestApplyTransformations(t *testing.T) {
 
 	annotations := ProtoFieldAnnotations{}
 
-	stats := applyTransformations(doc, descriptions, fieldTypes, annotations)
+	excludePatterns := []string{} // No exclusions for this test
+
+	stats := applyTransformations(doc, descriptions, fieldTypes, annotations, excludePatterns)
 
 	// Verify stats
 	assert.Equal(t, 1, stats.FiltersFlatted, "expected 1 parameter to be flattened")
 	assert.Equal(t, 1, stats.SchemasFixed, "expected 1 schema to be fixed")
 	assert.Equal(t, 1, stats.TypesFixed, "expected 1 type to be fixed")
+	assert.Equal(t, 0, stats.PathsExcluded, "expected 0 paths to be excluded")
 
 	// Verify parameter was renamed
 	param := doc.Paths.Map()["/api/v1/test"].Get.Parameters[0].Value

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -37,6 +37,9 @@ api:
   # Only tables with these prefixes will be exposed via REST API
   expose_prefixes:
     - fct
+  # Exclude tables matching these patterns from API exposure
+  exclude:
+    - "*_local"
 
 telemetry:
   enabled: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type ProtoConfig struct {
 type APIConfig struct {
 	BasePath       string   `mapstructure:"base_path"`
 	ExposePrefixes []string `mapstructure:"expose_prefixes"`
+	Exclude        []string `mapstructure:"exclude"`
 }
 
 // ServerConfig holds server-specific configuration.


### PR DESCRIPTION
- Add `exclude` lists to both discovery and API config sections
- Extend Makefile to translate wildcard patterns into SQL LIKE clauses
- Teach openapi-preprocess to read exclude patterns from config and filter matching paths and tags from the generated OpenAPI spec
- Update example config and CI workflow to exclude *_local tables