### PR TITLE
feat: split metrics endpoint into a dedicated server

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,5 +1,6 @@
 server:
   port: 8080
+  metrics_port: 9090
   host: 0.0.0.0
   read_header_timeout: 10s
   read_timeout: 30s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,8 +33,9 @@ type APIConfig struct {
 
 // ServerConfig holds server-specific configuration.
 type ServerConfig struct {
-	Port int    `mapstructure:"port"`
-	Host string `mapstructure:"host"`
+	Port        int    `mapstructure:"port"`
+	MetricsPort int    `mapstructure:"metrics_port"`
+	Host        string `mapstructure:"host"`
 
 	// HTTP server timeouts
 	ReadHeaderTimeout time.Duration `mapstructure:"read_header_timeout"`
@@ -102,6 +103,7 @@ func Load(configFile string) (*Config, error) {
 
 	// Server defaults
 	viper.SetDefault("server.port", 8080)
+	viper.SetDefault("server.metrics_port", 9090)
 	viper.SetDefault("server.host", "0.0.0.0")
 	viper.SetDefault("server.read_header_timeout", 10*time.Second)
 	viper.SetDefault("server.read_timeout", 30*time.Second)


### PR DESCRIPTION
- Extract /metrics handler from the main API server to a separate HTTP server listening on a configurable port (default 9090).
- Add MetricsPort field to ServerConfig and load it from config file.
- Update main.go to start and gracefully shutdown both API and metrics servers independently.
- Remove /metrics exclusion from gzip middleware since it now lives on a different port.