### PR TITLE
refactor: rename in/not_in to in_values/not_in_values for clarity

### DIFF
--- a/cmd/tools/generate-implementation/endpoints.go
+++ b/cmd/tools/generate-implementation/endpoints.go
@@ -314,7 +314,7 @@ func generateBuilderArgs(params []Param, filterType string) string {
 		}
 	} else if strings.Contains(filterType, "String") {
 		// String filters
-		baseOps := []string{"eq", "ne", "contains", "starts_with", "ends_with", "like", "not_like", "in", "not_in"}
+		baseOps := []string{"eq", "ne", "contains", "starts_with", "ends_with", "like", "not_like", "in_values", "not_in_values"}
 		for _, op := range baseOps {
 			if arg, ok := argMap[op]; ok {
 				args = append(args, arg)

--- a/cmd/tools/generate-implementation/endpoints_test.go
+++ b/cmd/tools/generate-implementation/endpoints_test.go
@@ -138,10 +138,10 @@ func TestGenerateBuilderArgs(t *testing.T) {
 		{
 			name: "string filter with in list",
 			params: []Param{
-				{Name: "network_in", Operator: "in"},
+				{Name: "network_in_values", Operator: "in_values"},
 			},
 			filterType: "StringFilter",
-			expected:   "nil, nil, nil, nil, nil, nil, nil, params.NetworkIn, nil",
+			expected:   "nil, nil, nil, nil, nil, nil, nil, params.NetworkInValues, nil",
 		},
 		{
 			name: "bool filter",

--- a/cmd/tools/generate-implementation/filter_builders_test.go
+++ b/cmd/tools/generate-implementation/filter_builders_test.go
@@ -244,9 +244,21 @@ func TestGenerateScalarFilterBuilder(t *testing.T) {
 			expectedInCode: []string{
 				"func buildUInt32Filter(eq, ne, lt, lte, gt, gte *uint32, in, notIn *string) *clickhouse.UInt32Filter",
 				"if eq != nil {",
+				// Original combination
 				"if gte != nil && lte != nil {",
 				"Between: &clickhouse.UInt32Range{",
 				"&wrapperspb.UInt32Value{Value: *lte}",
+				// NEW: gte + lt combination
+				"if gte != nil && lt != nil {",
+				"if *lt > 0 && *lt > *gte {",
+				"&wrapperspb.UInt32Value{Value: *lt - 1}",
+				// NEW: gt + lte combination
+				"if gt != nil && lte != nil {",
+				"Min: *gt + 1",
+				// NEW: gt + lt combination
+				"if gt != nil && lt != nil {",
+				"if *lt > 0 && *lt > *gt + 1 {",
+				// Fallback individual operators
 				"if lte != nil {",
 				"if gte != nil {",
 				"if lt != nil {",
@@ -336,8 +348,17 @@ func TestGenerateNullableFilterBuilder(t *testing.T) {
 				"func buildNullableUInt32Filter(eq, ne, lt, lte, gt, gte *uint32, in, notIn *string, isNull, isNotNull *bool) *clickhouse.NullableUInt32Filter",
 				"if isNull != nil && *isNull {",
 				"if isNotNull != nil && *isNotNull {",
+				// Original combination
 				"if gte != nil && lte != nil {",
 				"Between: &clickhouse.UInt32Range{",
+				// NEW: gte + lt combination
+				"if gte != nil && lt != nil {",
+				"if *lt > 0 && *lt > *gte {",
+				// NEW: gt + lte combination
+				"if gt != nil && lte != nil {",
+				// NEW: gt + lt combination
+				"if gt != nil && lt != nil {",
+				"if *lt > 0 && *lt > *gt + 1 {",
 			},
 			notInCode: []string{
 				"contains",


### PR DESCRIPTION
feat: extend numeric filter builders to auto-combine range operators into BETWEEN
fix: correct console log to show actual listening port instead of constant