### PR TITLE
perf(clickhouse): enable LZ4 compression for all client connections

### DIFF
--- a/internal/database/clickhouse.go
+++ b/internal/database/clickhouse.go
@@ -170,6 +170,9 @@ func createClickHouseOptions(cfg *config.ClickHouseConfig, parsedURL *url.URL) *
 		Settings: clickhouse.Settings{
 			"max_execution_time": cfg.MaxExecutionTime,
 		},
+		Compression: &clickhouse.Compression{
+			Method: clickhouse.CompressionLZ4,
+		},
 		DialTimeout: cfg.DialTimeout,
 		ReadTimeout: cfg.ReadTimeout,
 	}


### PR DESCRIPTION
> compress - specify the compression algorithm: none (default), zstd, lz4, lz4hc, gzip, deflate, br. If set to true, lz4 will be used.
