### PR TITLE
feat(telemetry): add table label to all ClickHouse metrics

### DIFF
--- a/internal/telemetry/database.go
+++ b/internal/telemetry/database.go
@@ -19,8 +19,8 @@ import (
 )
 
 // tableNameRegex matches table names in FROM and INTO clauses.
-// Handles: FROM table, FROM db.table, FROM "table", FROM `table`.
-var tableNameRegex = regexp.MustCompile(`(?i)\b(?:FROM|INTO)\s+["'\x60]?(?:(\w+)\.)?(\w+)["'\x60]?`)
+// Handles: FROM table, FROM db.table, FROM "db"."table", FROM `db`.`table`.
+var tableNameRegex = regexp.MustCompile(`(?i)\b(?:FROM|INTO)\s+(?:["'\x60]?(\w+)["'\x60]?\.)?["'\x60]?(\w+)["'\x60]?`)
 
 // extractTableName extracts the table name from a SQL query.
 func extractTableName(query string) string {

--- a/internal/telemetry/database.go
+++ b/internal/telemetry/database.go
@@ -3,6 +3,7 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -17,6 +18,20 @@ import (
 	"github.com/ethpandaops/cbt-api/internal/database"
 )
 
+// tableNameRegex matches table names in FROM and INTO clauses.
+// Handles: FROM table, FROM db.table, FROM "table", FROM `table`.
+var tableNameRegex = regexp.MustCompile(`(?i)\b(?:FROM|INTO)\s+["'\x60]?(?:(\w+)\.)?(\w+)["'\x60]?`)
+
+// extractTableName extracts the table name from a SQL query.
+func extractTableName(query string) string {
+	matches := tableNameRegex.FindStringSubmatch(query)
+	if len(matches) >= 3 && matches[2] != "" {
+		return matches[2]
+	}
+
+	return "unknown"
+}
+
 var (
 	clickhouseQueryDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -26,7 +41,7 @@ var (
 			Help:      "ClickHouse query duration in seconds",
 			Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		},
-		[]string{"operation", "sql_operation"},
+		[]string{"operation", "sql_operation", "table"},
 	)
 
 	clickhouseQueriesTotal = prometheus.NewCounterVec(
@@ -36,7 +51,7 @@ var (
 			Name:      "queries_total",
 			Help:      "Total number of ClickHouse queries",
 		},
-		[]string{"operation", "sql_operation"},
+		[]string{"operation", "sql_operation", "table"},
 	)
 
 	clickhouseQueryErrorsTotal = prometheus.NewCounterVec(
@@ -46,7 +61,7 @@ var (
 			Name:      "query_errors_total",
 			Help:      "Total number of ClickHouse query errors",
 		},
-		[]string{"operation", "sql_operation"},
+		[]string{"operation", "sql_operation", "table"},
 	)
 
 	clickhouseRowsReturned = prometheus.NewHistogramVec(
@@ -57,7 +72,7 @@ var (
 			Help:      "Number of rows returned by ClickHouse queries",
 			Buckets:   []float64{1, 10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000},
 		},
-		[]string{"operation", "sql_operation"},
+		[]string{"operation", "sql_operation", "table"},
 	)
 )
 
@@ -93,23 +108,24 @@ func NewTracedClient(client *database.Client, dbName string, logger logrus.Field
 func (c *TracedClient) Query(ctx context.Context, query string, args ...any) (driver.Rows, error) {
 	start := time.Now()
 	sqlOp := extractSQLOperation(query)
+	table := extractTableName(query)
 
 	ctx, span := c.startSpan(ctx, "Query", query, args...)
 	defer span.End()
 
 	// Record query count
-	clickhouseQueriesTotal.WithLabelValues("Query", sqlOp).Inc()
+	clickhouseQueriesTotal.WithLabelValues("Query", sqlOp, table).Inc()
 
 	rows, err := c.client.Query(ctx, query, args...)
 	duration := time.Since(start).Seconds()
 
 	// Record query duration
-	clickhouseQueryDuration.WithLabelValues("Query", sqlOp).Observe(duration)
+	clickhouseQueryDuration.WithLabelValues("Query", sqlOp, table).Observe(duration)
 
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		clickhouseQueryErrorsTotal.WithLabelValues("Query", sqlOp).Inc()
+		clickhouseQueryErrorsTotal.WithLabelValues("Query", sqlOp, table).Inc()
 
 		return nil, err
 	}
@@ -119,6 +135,7 @@ func (c *TracedClient) Query(ctx context.Context, query string, args ...any) (dr
 		span:      span,
 		operation: "Query",
 		sqlOp:     sqlOp,
+		table:     table,
 	}, nil
 }
 
@@ -126,18 +143,19 @@ func (c *TracedClient) Query(ctx context.Context, query string, args ...any) (dr
 func (c *TracedClient) QueryRow(ctx context.Context, query string, args ...any) driver.Row {
 	start := time.Now()
 	sqlOp := extractSQLOperation(query)
+	table := extractTableName(query)
 
 	ctx, span := c.startSpan(ctx, "QueryRow", query, args...)
 	defer span.End()
 
 	// Record query count
-	clickhouseQueriesTotal.WithLabelValues("QueryRow", sqlOp).Inc()
+	clickhouseQueriesTotal.WithLabelValues("QueryRow", sqlOp, table).Inc()
 
 	row := c.client.QueryRow(ctx, query, args...)
 	duration := time.Since(start).Seconds()
 
 	// Record query duration
-	clickhouseQueryDuration.WithLabelValues("QueryRow", sqlOp).Observe(duration)
+	clickhouseQueryDuration.WithLabelValues("QueryRow", sqlOp, table).Observe(duration)
 
 	// Note: driver.Row doesn't expose errors until Scan() is called
 	// We record the operation but can't capture row-level errors here.
@@ -150,23 +168,24 @@ func (c *TracedClient) QueryRow(ctx context.Context, query string, args ...any) 
 func (c *TracedClient) Select(ctx context.Context, dest any, query string, args ...any) error {
 	start := time.Now()
 	sqlOp := extractSQLOperation(query)
+	table := extractTableName(query)
 
 	ctx, span := c.startSpan(ctx, "Select", query, args...)
 	defer span.End()
 
 	// Record query count
-	clickhouseQueriesTotal.WithLabelValues("Select", sqlOp).Inc()
+	clickhouseQueriesTotal.WithLabelValues("Select", sqlOp, table).Inc()
 
 	err := c.client.Select(ctx, dest, query, args...)
 	duration := time.Since(start).Seconds()
 
 	// Record query duration
-	clickhouseQueryDuration.WithLabelValues("Select", sqlOp).Observe(duration)
+	clickhouseQueryDuration.WithLabelValues("Select", sqlOp, table).Observe(duration)
 
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		clickhouseQueryErrorsTotal.WithLabelValues("Select", sqlOp).Inc()
+		clickhouseQueryErrorsTotal.WithLabelValues("Select", sqlOp, table).Inc()
 
 		return err
 	}
@@ -180,23 +199,24 @@ func (c *TracedClient) Select(ctx context.Context, dest any, query string, args 
 func (c *TracedClient) Exec(ctx context.Context, query string, args ...any) error {
 	start := time.Now()
 	sqlOp := extractSQLOperation(query)
+	table := extractTableName(query)
 
 	ctx, span := c.startSpan(ctx, "Exec", query, args...)
 	defer span.End()
 
 	// Record query count
-	clickhouseQueriesTotal.WithLabelValues("Exec", sqlOp).Inc()
+	clickhouseQueriesTotal.WithLabelValues("Exec", sqlOp, table).Inc()
 
 	err := c.client.Exec(ctx, query, args...)
 	duration := time.Since(start).Seconds()
 
 	// Record query duration
-	clickhouseQueryDuration.WithLabelValues("Exec", sqlOp).Observe(duration)
+	clickhouseQueryDuration.WithLabelValues("Exec", sqlOp, table).Observe(duration)
 
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		clickhouseQueryErrorsTotal.WithLabelValues("Exec", sqlOp).Inc()
+		clickhouseQueryErrorsTotal.WithLabelValues("Exec", sqlOp, table).Inc()
 
 		return err
 	}
@@ -269,6 +289,7 @@ type tracedRows struct {
 	rowCount  int64
 	operation string
 	sqlOp     string
+	table     string
 }
 
 // Next wraps the original Next and counts rows.
@@ -283,7 +304,7 @@ func (r *tracedRows) Next() bool {
 
 		// Record rows returned metric
 		if r.rowCount > 0 {
-			clickhouseRowsReturned.WithLabelValues(r.operation, r.sqlOp).Observe(float64(r.rowCount))
+			clickhouseRowsReturned.WithLabelValues(r.operation, r.sqlOp, r.table).Observe(float64(r.rowCount))
 		}
 	}
 
@@ -295,7 +316,7 @@ func (r *tracedRows) Close() error {
 	// Record final row count if not already done
 	if r.rowCount > 0 {
 		r.span.SetAttributes(AttrDBRowsReturned.Int64(r.rowCount))
-		clickhouseRowsReturned.WithLabelValues(r.operation, r.sqlOp).Observe(float64(r.rowCount))
+		clickhouseRowsReturned.WithLabelValues(r.operation, r.sqlOp, r.table).Observe(float64(r.rowCount))
 	}
 
 	return r.Rows.Close()

--- a/internal/telemetry/database_test.go
+++ b/internal/telemetry/database_test.go
@@ -58,6 +58,26 @@ func TestExtractTableName(t *testing.T) {
 			expected: "my_table",
 		},
 		{
+			name:     "quoted database and table",
+			query:    `SELECT * FROM "mainnet"."fct_blocks"`,
+			expected: "fct_blocks",
+		},
+		{
+			name:     "backtick quoted database and table",
+			query:    "SELECT * FROM `mainnet`.`fct_blocks`",
+			expected: "fct_blocks",
+		},
+		{
+			name:     "mixed quotes - db quoted",
+			query:    `SELECT * FROM "mainnet".fct_blocks`,
+			expected: "fct_blocks",
+		},
+		{
+			name:     "mixed quotes - table quoted",
+			query:    `SELECT * FROM mainnet."fct_blocks"`,
+			expected: "fct_blocks",
+		},
+		{
 			name:     "complex query with joins",
 			query:    "SELECT a.id FROM users a JOIN orders b ON a.id = b.user_id",
 			expected: "users",

--- a/internal/telemetry/database_test.go
+++ b/internal/telemetry/database_test.go
@@ -1,0 +1,144 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTableName(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "simple select",
+			query:    "SELECT * FROM users",
+			expected: "users",
+		},
+		{
+			name:     "select with database prefix",
+			query:    "SELECT * FROM mydb.users",
+			expected: "users",
+		},
+		{
+			name:     "select with where clause",
+			query:    "SELECT id, name FROM orders WHERE status = 'active'",
+			expected: "orders",
+		},
+		{
+			name:     "insert into",
+			query:    "INSERT INTO events (id, data) VALUES (?, ?)",
+			expected: "events",
+		},
+		{
+			name:     "insert into with database",
+			query:    "INSERT INTO analytics.events (id) VALUES (?)",
+			expected: "events",
+		},
+		{
+			name:     "lowercase from",
+			query:    "select * from fct_blocks where slot > 100",
+			expected: "fct_blocks",
+		},
+		{
+			name:     "mixed case",
+			query:    "SELECT * From FctAttestations WHERE epoch = 1",
+			expected: "FctAttestations",
+		},
+		{
+			name:     "with backticks",
+			query:    "SELECT * FROM `my_table`",
+			expected: "my_table",
+		},
+		{
+			name:     "with double quotes",
+			query:    `SELECT * FROM "my_table"`,
+			expected: "my_table",
+		},
+		{
+			name:     "complex query with joins",
+			query:    "SELECT a.id FROM users a JOIN orders b ON a.id = b.user_id",
+			expected: "users",
+		},
+		{
+			name:     "subquery - extracts outer table",
+			query:    "SELECT * FROM blocks WHERE id IN (SELECT block_id FROM transactions)",
+			expected: "blocks",
+		},
+		{
+			name:     "no from clause",
+			query:    "SELECT 1",
+			expected: "unknown",
+		},
+		{
+			name:     "empty query",
+			query:    "",
+			expected: "unknown",
+		},
+		{
+			name:     "create table",
+			query:    "CREATE TABLE test (id Int32)",
+			expected: "unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractTableName(tt.query)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractSQLOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			name:     "select",
+			query:    "SELECT * FROM users",
+			expected: "SELECT",
+		},
+		{
+			name:     "insert",
+			query:    "INSERT INTO users VALUES (1)",
+			expected: "INSERT",
+		},
+		{
+			name:     "update",
+			query:    "UPDATE users SET name = 'test'",
+			expected: "UPDATE",
+		},
+		{
+			name:     "delete",
+			query:    "DELETE FROM users WHERE id = 1",
+			expected: "DELETE",
+		},
+		{
+			name:     "lowercase",
+			query:    "select * from users",
+			expected: "SELECT",
+		},
+		{
+			name:     "with leading whitespace",
+			query:    "   SELECT * FROM users",
+			expected: "SELECT",
+		},
+		{
+			name:     "empty query",
+			query:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractSQLOperation(tt.query)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Add `table` label to ClickHouse Prometheus metrics for query-level performance visibility
- Add `extractTableName()` function to parse table names from SQL queries
- Add unit tests for table and SQL operation extraction