### PR TITLE
fix(endpoints.go): add cap hints

### DIFF
--- a/cmd/tools/generate-implementation/endpoints.go
+++ b/cmd/tools/generate-implementation/endpoints.go
@@ -100,7 +100,7 @@ func (s *Server) %s(w http.ResponseWriter, r *http.Request, params handlers.%s) 
 
 	// Scan results directly into OpenAPI types
 	_, scanSpan := tracer.Start(ctx, "handler.scanResults")
-	var items []handlers.%s
+	items := make([]handlers.%s, 0, req.PageSize)
 	for rows.Next() {
 		var item handlers.%s
 		if err := rows.ScanStruct(&item); err != nil {


### PR DESCRIPTION
Should help given some of our req's are 10k page sizes.