### PR TITLE
chore(ci): bump Go to 1.26.3 across project and CI

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -122,4 +122,4 @@ jobs:
             -e DOCKER_PASSWORD=${{ secrets.DOCKERHUB_TOKEN }} \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e RELEASE_SUFFIX=${{ env.RELEASE_SUFFIX }} \
-            goreleaser/goreleaser-cross:v1.26.1 release --clean --config .goreleaser.yaml.new
+            goreleaser/goreleaser-cross:v1.26.3 release --clean --config .goreleaser.yaml.new

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.26.1
+golang 1.26.3
 golangci-lint 2.12.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 RUN apk add --no-cache make git ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ethpandaops/cbt-api
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.44.0


### PR DESCRIPTION
## Summary

Bumps Go from **1.26.1 → 1.26.3** across the project and CI.

The earlier bump to 1.26.1 broke the `goreleaser` release job — the
`goreleaser/goreleaser-cross:v1.26.1` image was never published, so the
`docker run` failed with `manifest unknown` (exit code 125), e.g.
[run 27745326256](https://github.com/ethpandaops/cbt-api/actions/runs/27745326256/job/82084673292).

`goreleaser-cross` only publishes up to **v1.26.3** (there is no v1.26.4 image
either), so aligning everything to 1.26.3 keeps `GOTOOLCHAIN=local` reproducible
builds working and unblocks releases.

## Changes

| File | From | To |
|---|---|---|
| `go.mod` | `go 1.26.1` | `go 1.26.3` |
| `.tool-versions` | `golang 1.26.1` | `golang 1.26.3` |
| `Dockerfile` | `golang:1.26.1-alpine` | `golang:1.26.3-alpine` |
| `.github/workflows/goreleaser.yaml` | `goreleaser-cross:v1.26.1` | `goreleaser-cross:v1.26.3` |

The `setup-go` steps use `go-version-file: go.mod` and pick up 1.26.3
automatically. `golangci-lint` is left at 2.12.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)