### PR TITLE
feat: generate importable typed Go client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,6 +313,10 @@ run: build-binary
 	@printf "$(CYAN)==> Copying OpenAPI spec for embedding...$(RESET)\n"
 	@cp openapi.yaml internal/server/openapi.yaml
 	@printf "$(GREEN)✓ Server implementation generated: internal/server/implementation.go$(RESET)\n"
+	@printf "$(CYAN)==> Generating Go client from OpenAPI spec...$(RESET)\n"
+	@mkdir -p pkg/client
+	@oapi-codegen --config oapi-codegen-client.yaml openapi.yaml > pkg/client/client.gen.go
+	@printf "$(GREEN)✓ Go client generated: pkg/client/client.gen.go$(RESET)\n"
 
 # Clean generated files and build artifacts
 clean:
@@ -325,6 +329,7 @@ clean:
 	@rm -f internal/handlers/generated.go
 	@rm -f internal/server/implementation.go
 	@rm -f internal/server/openapi.yaml
+	@rm -f pkg/client/client.gen.go
 	@rm -f /tmp/cbt-api-test.log /tmp/cbt-api-test.pid config.test.yaml
 	@printf "$(GREEN)✓ Cleaned$(RESET)\n"
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ cbt-api is a **generic REST API generator** for any ClickHouse database managed 
 - `openapi.yaml` - OpenAPI 3.0 specification with flattened filter parameters
 - `internal/handlers/generated.go` - Server interface (via oapi-codegen)
 - `internal/server/implementation.go` - Complete server implementation with automatic query building
+- `pkg/client/client.gen.go` - Importable typed Go client for every endpoint (via oapi-codegen), so Go consumers call the API with generated types instead of hand-rolled HTTP and JSON structs:
+
+```go
+c, _ := client.NewClientWithResponses("https://cbt-api.example.com")
+
+resp, _ := c.AdminCbtIncrementalServiceListWithResponse(ctx, &client.AdminCbtIncrementalServiceListParams{
+    DatabaseEq: ptr("mainnet"),
+})
+```
 
 ## Quick Start
 

--- a/oapi-codegen-client.yaml
+++ b/oapi-codegen-client.yaml
@@ -1,0 +1,14 @@
+# oapi-codegen configuration for generating the importable Go client
+# See: https://github.com/oapi-codegen/oapi-codegen
+
+package: client
+
+generate:
+  models: true       # Request/response types
+  client: true       # Typed HTTP client for every endpoint
+
+output-options:
+  skip-prune: true
+  skip-fmt: false
+
+import-mapping: {}


### PR DESCRIPTION
make generate now also emits `pkg/client/client.gen.go` via oapi-codegen (client + models) from the same openapi.yaml as the server — no new make command. Go consumers of a cbt-api deployment (e.g. lab-backend's hand-rolled bounds fetcher, dora) get generated request params and response types for every endpoint instead of hand-rolled HTTP and JSON structs. Validated against the test ClickHouse schema: full `make proto generate` pipeline plus `go build ./...` pass.

https://claude.ai/code/session_01PqWvkAjYgCjjhtu83gJeXP